### PR TITLE
Update lib.rs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,9 +65,9 @@ bitflags! {
     }
 }
 
-pub type ErrorsCallback = Arc<Fn(Error) -> bool + Send + Sync>;
-pub type PreFetchCallback = Arc<Fn(&Url) -> bool + Send + Sync>;
-pub type PostFetchCallback = Arc<Fn(&Url, &HeaderMap) -> bool + Send + Sync>;
+pub type ErrorsCallback = Arc<dyn Fn(Error) -> bool + Send + Sync>;
+pub type PreFetchCallback = Arc<dyn Fn(&Url) -> bool + Send + Sync>;
+pub type PostFetchCallback = Arc<dyn Fn(&Url, &HeaderMap) -> bool + Send + Sync>;
 
 /// Defines whether to crawl from a single source, or from multiple sources.
 /// 


### PR DESCRIPTION
Added 'dyn' to functions to supress warnings on cargo build

As in:

warning: trait objects without an explicit `dyn` are deprecated
  --> src/lib.rs:68:31
   |
68 | pub type ErrorsCallback = Arc<Fn(Error) -> bool + Send + Sync>;
   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `dyn`: `dyn Fn(Error) -> bool + Send + Sync`
use std::time::Duration;
   |
   = note: `#[warn(bare_trait_objects)]` on by default